### PR TITLE
Add TLS support

### DIFF
--- a/lib/stratum.js
+++ b/lib/stratum.js
@@ -6,13 +6,7 @@ var fs = require('fs');
 
 var util = require('./util.js');
 
-const home = process.env['HOME'];
-const TLSoptions = {
-    key: fs.readFileSync(home + '/server-key.pem'),
-    cert: fs.readFileSync(home +'/server-cert.pem'),
-    requireCert: true, //small note to whoever reads this, claymore doesn't even send his devfee to pool the miner mines anymore, not sure why he still offers that 2% fee for ssl
-    ca: [fs.readFileSync(home +'/server-csr.pem')]
-}
+var TLSoptions;
 
 var SubscriptionCounter = function(){
     var count = 0;
@@ -438,6 +432,14 @@ var StratumServer = exports.Server = function StratumServer(options, authorizeFn
 
         //SetupBroadcasting();
 
+        //if (Object.keys(options.tlsOptions.enabled) == true) {
+            TLSoptions = {
+                key: fs.readFileSync(options.tlsOptions.serverKey),
+                cert: fs.readFileSync(options.tlsOptions.serverCert),
+                ca: fs.readFileSync(options.tlsOptions.ca),
+                requireCert: true
+            }
+        //}
 
         var serversStarted = 0;
         Object.keys(options.ports).forEach(function(port){

--- a/lib/stratum.js
+++ b/lib/stratum.js
@@ -1,9 +1,18 @@
 var BigNum = require('bignum');
 var net = require('net');
 var events = require('events');
+var tls = require('tls');
+var fs = require('fs');
 
 var util = require('./util.js');
 
+const home = process.env['HOME'];
+const TLSoptions = {
+    key: fs.readFileSync(home + '/server-key.pem'),
+    cert: fs.readFileSync(home +'/server-cert.pem'),
+    requireCert: true, //small note to whoever reads this, claymore doesn't even send his devfee to pool the miner mines anymore, not sure why he still offers that 2% fee for ssl
+    ca: [fs.readFileSync(home +'/server-csr.pem')]
+}
 
 var SubscriptionCounter = function(){
     var count = 0;
@@ -432,13 +441,23 @@ var StratumServer = exports.Server = function StratumServer(options, authorizeFn
 
         var serversStarted = 0;
         Object.keys(options.ports).forEach(function(port){
-            net.createServer({allowHalfOpen: false}, function(socket) {
-                _this.handleNewClient(socket);
-            }).listen(parseInt(port), function() {
+	    if (port.tls = false || undefined) {   //  = because I always see people add quotations to bools on json :p
+                net.createServer({allowHalfOpen: false}, function(socket) {
+                    _this.handleNewClient(socket);
+            	}).listen(parseInt(port), function() {
                 serversStarted++;
                 if (serversStarted == Object.keys(options.ports).length)
                     _this.emit('started');
-            });
+                });
+            } else if (port.tls = true ) {
+                tls.createServer(TLSoptions, function(socket) {
+                    _this.handleNewClient(socket);
+                }).listen(parseInt(port), function() {
+                    serversStarted++;
+                    if (serversStarted == Object.keys(options.ports).length)
+                        _this.emit('started');
+                });
+            }
         });
     })();
 

--- a/lib/stratum.js
+++ b/lib/stratum.js
@@ -432,14 +432,14 @@ var StratumServer = exports.Server = function StratumServer(options, authorizeFn
 
         //SetupBroadcasting();
 
-        //if (Object.keys(options.tlsOptions.enabled) == true) {
+        if (options.tlsOptions.enabled == true) {
             TLSoptions = {
                 key: fs.readFileSync(options.tlsOptions.serverKey),
                 cert: fs.readFileSync(options.tlsOptions.serverCert),
                 ca: fs.readFileSync(options.tlsOptions.ca),
                 requireCert: true
             }
-        //}
+        }
 
         var serversStarted = 0;
         Object.keys(options.ports).forEach(function(port){

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -56,9 +56,9 @@ exports.createGeneration = function(blockHeight, blockReward, feeReward, recipie
     tx.addInput(new Buffer('0000000000000000000000000000000000000000000000000000000000000000', 'hex'),
         4294967295,
         4294967295,
-        new Buffer.concat([serializedBlockHeight
-            //Buffer('5a2d4e4f4d5021', 'hex')]) // Z-NOMP!
-    ]));
+        new Buffer.concat([serializedBlockHeight,
+            Buffer('5a2d4e4f4d50212068747470733a2f2f6769746875622e636f6d2f6a6f7368756179616275742f7a2d6e6f6d70', 'hex')]) // Z-NOMP!
+    );
 
     // calculate total fees
     var feePercent = 0;


### PR DESCRIPTION
Ill add documentation to z-nomp repo's soon, <s>TODO: pull where the certs are from a config,</s> fixes #7 and https://github.com/joshuayabut/z-nomp/issues/52.

Claymore's miner doesn't seem to do any ssl verification as long as it gets the public key, optiminer does actual ssl verification and doesn't work with self signed certs, use https://letsencrypt.org/certificates.

Sample conf: 
   ```
  "tlsOptions": {        
        "enabled": true,        
        "serverKey":"/home/aayan/Downloads/server-key.pem",       
        "serverCert":"/home/aayan/Downloads/server-cert.pem",        
        "ca":"/home/aayan/Downloads/server-csr.pem"    
  },
 "ports": {
        "3032": {
            "diff": 0.05,
             "tls": false,
            "varDiff": {
                "minDiff": 0.04,
                "maxDiff": 16,
                "targetTime": 15,
                "retargetTime": 60,
                "variancePercent": 30
            }
        }, "3032": {
            "diff": 0.05,
            "tls": true,
            "varDiff": {
                "minDiff": 0.04,
                "maxDiff": 16,
                "targetTime": 15,
                "retargetTime": 60,
                "variancePercent": 30
            }
        }
    },

```