### PR TITLE
Improved duplicate block rejection

### DIFF
--- a/lib/blockTemplate.js
+++ b/lib/blockTemplate.js
@@ -23,13 +23,13 @@ var BlockTemplate = module.exports = function BlockTemplate(jobId, rpcData, extr
     this.difficulty = parseFloat((diff1 / this.target.toNumber()).toFixed(9));
 
     // generate the fees and coinbase tx
-    
-    var blockReward;
-    
-    if (payFoundersReward) {
-       blockReward = (this.rpcData.miner + this.rpcData.founders) * 100000000;
-    } else {
-       blockReward = (this.rpcData.miner) * 100000000;
+    var blockReward = (this.rpcData.miner + this.rpcData.founders) * 100000000;
+    if (payFoundersReward !== true) {
+        blockReward = (this.rpcData.miner) * 100000000;
+    }
+    // missing founders?
+    if (!this.rpcData.founders || this.rpcData.founders.length <= 0) {
+        blockReward = (this.rpcData.miner) * 100000000;
     }
     
     var fees = [];

--- a/lib/blockTemplate.js
+++ b/lib/blockTemplate.js
@@ -23,13 +23,13 @@ var BlockTemplate = module.exports = function BlockTemplate(jobId, rpcData, extr
     this.difficulty = parseFloat((diff1 / this.target.toNumber()).toFixed(9));
 
     // generate the fees and coinbase tx
-    var blockReward = (this.rpcData.miner + this.rpcData.founders) * 100000000;
-    if (payFoundersReward !== true) {
-        blockReward = (this.rpcData.miner) * 100000000;
-    }
-    // missing founders?
-    if (!this.rpcData.founders || this.rpcData.founders.length <= 0) {
-        blockReward = (this.rpcData.miner) * 100000000;
+    var blockReward = (this.rpcData.miner) * 100000000;
+    if (payFoundersReward === true) {
+        if (!this.rpcData.founders || this.rpcData.founders.length <= 0) {
+            console.log('Error, founders reward missing for block template!');
+        } else {
+            blockReward = (this.rpcData.miner + this.rpcData.founders) * 100000000;
+        }
     }
     
     var fees = [];

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -326,8 +326,12 @@ var pool = module.exports = function pool(options, authorizeFn) {
                     jobManagerLastSubmitBlockHex = blockHex;
                     SubmitBlock(blockHex, function () {
                         CheckBlockAccepted(shareData.blockHash, function (isAccepted, tx) {
-                            isValidBlock = isAccepted;
-                            shareData.txHash = tx;
+                            isValidBlock = isAccepted === true;
+                            if (isValidBlock === true) {
+                                shareData.txHash = tx;
+                            } else {
+                                shareData.error = tx;
+                            }
                             emitShare();
                             GetBlockTemplate(function (error, result, foundNewBlock) {
                                 jobManagerSubmittingBlock = false;
@@ -613,11 +617,14 @@ var pool = module.exports = function pool(options, authorizeFn) {
                     if (validResults[0].response.confirmations >= 0) {
                         // accepted valid block!
                         callback(true, validResults[0].response.tx[0]);
-                        return;
+                    } else {
+                        // reject invalid block, due to confirmations
+                        callback(false, {"confirmations": validResults[0].response.confirmations});
                     }
+                    return;
                 }
                 // invalid block, rejected
-                callback(false);
+                callback(false, {"unknown": "check coin daemon logs"});
             }
         );
     }

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -336,7 +336,7 @@ var pool = module.exports = function pool(options, authorizeFn) {
                                 }
                             });
                         });
-                    });                    
+                    });
                 }
             }
         }).on('log', function (severity, message) {
@@ -607,15 +607,19 @@ var pool = module.exports = function pool(options, authorizeFn) {
                 var validResults = results.filter(function (result) {
                     return result.response && (result.response.hash === blockHash)
                 });
+                // do we have any results?
                 if (validResults.length >= 1) {
-                    callback(true, validResults[0].response.tx[0]);
+                    // check for invalid blocks with negative confirmations
+                    if (validResults[0].response.confirmations >= 0) {
+                        // accepted valid block!
+                        callback(true, validResults[0].response.tx[0]);
+                        return;
+                    }
                 }
-                else {
-                    callback(false);
-                }
+                // invalid block, rejected
+                callback(false);
             }
         );
-        //}, 500);
     }
 
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -282,6 +282,9 @@ var pool = module.exports = function pool(options, authorizeFn) {
         }
         options.recipients = recipients;
     }
+ 
+    var jobManagerSubmittingBlock = false;
+    var jobManagerLastSubmitBlockHex = false;
 
     function SetupJobManager() {
 
@@ -314,19 +317,27 @@ var pool = module.exports = function pool(options, authorizeFn) {
             if (!isValidBlock)
                 emitShare();
             else {
-                SubmitBlock(blockHex, function () {
-                    CheckBlockAccepted(shareData.blockHash, function (isAccepted, tx) {
-                        isValidBlock = isAccepted;
-                        shareData.txHash = tx;
-                        emitShare();
-
-                        GetBlockTemplate(function (error, result, foundNewBlock) {
-                            if (foundNewBlock)
-                                emitLog('Block notification via RPC after block submission');
+                if (jobManagerSubmittingBlock === true) {
+                    emitWarningLog('Warning, ignored new submit block while processing previous submit block.');
+                } else if (jobManagerLastSubmitBlockHex === blockHex) {
+                    emitWarningLog('Warning, ignored duplicate submit block ' + blockHex);
+                } else {
+                    jobManagerSubmittingBlock = true;
+                    jobManagerLastSubmitBlockHex = blockHex;
+                    SubmitBlock(blockHex, function () {
+                        CheckBlockAccepted(shareData.blockHash, function (isAccepted, tx) {
+                            isValidBlock = isAccepted;
+                            shareData.txHash = tx;
+                            emitShare();
+                            GetBlockTemplate(function (error, result, foundNewBlock) {
+                                jobManagerSubmittingBlock = false;
+                                if (foundNewBlock) {
+                                    emitLog('Block notification via RPC after block submission');
+                                }
+                            });
                         });
-
-                    });
-                });
+                    });                    
+                }
             }
         }).on('log', function (severity, message) {
             _this.emit('log', severity, message);
@@ -596,7 +607,6 @@ var pool = module.exports = function pool(options, authorizeFn) {
                 var validResults = results.filter(function (result) {
                     return result.response && (result.response.hash === blockHash)
                 });
-
                 if (validResults.length >= 1) {
                     callback(true, validResults[0].response.tx[0]);
                 }


### PR DESCRIPTION
Reduce Potential for https://github.com/z-classic/z-nomp/issues/86 - Improved duplicate block submission rejection
 * Do not allow block submission while processing previous block submission.
 * Do not process block submission with same blockhex as previous.
 * Do not accept blocks with negative confirmations (daemon invalidated blocks)

Added error tracking information when coin daemon rejects a submit block.
Improved handling of payFoundersReward