### PR TITLE
Update pool.js

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -282,8 +282,7 @@ var pool = module.exports = function pool(options, authorizeFn) {
         }
         options.recipients = recipients;
     }
- 
-    var jobManagerSubmittingBlock = false;
+
     var jobManagerLastSubmitBlockHex = false;
 
     function SetupJobManager() {
@@ -317,12 +316,9 @@ var pool = module.exports = function pool(options, authorizeFn) {
             if (!isValidBlock)
                 emitShare();
             else {
-                if (jobManagerSubmittingBlock === true) {
-                    emitWarningLog('Warning, ignored new submit block while processing previous submit block.');
-                } else if (jobManagerLastSubmitBlockHex === blockHex) {
+                if (jobManagerLastSubmitBlockHex === blockHex) {
                     emitWarningLog('Warning, ignored duplicate submit block ' + blockHex);
                 } else {
-                    jobManagerSubmittingBlock = true;
                     jobManagerLastSubmitBlockHex = blockHex;
                     SubmitBlock(blockHex, function () {
                         CheckBlockAccepted(shareData.blockHash, function (isAccepted, tx) {
@@ -334,7 +330,6 @@ var pool = module.exports = function pool(options, authorizeFn) {
                             }
                             emitShare();
                             GetBlockTemplate(function (error, result, foundNewBlock) {
-                                jobManagerSubmittingBlock = false;
                                 if (foundNewBlock) {
                                     emitLog('Block notification via RPC after block submission');
                                 }
@@ -567,7 +562,6 @@ var pool = module.exports = function pool(options, authorizeFn) {
 
 
     function GetBlockTemplate(callback) {
-
         function getBlockSubsidyandTemplate(callback) {
             _this.daemon.cmd('getblocksubsidy',
                 [],
@@ -580,6 +574,7 @@ var pool = module.exports = function pool(options, authorizeFn) {
 
 
         function getBlockTemplate(subsidy) {
+
             _this.daemon.cmd('getblocktemplate',
                 [{"capabilities": ["coinbasetxn", "workid", "coinbase/append"]}],
                 function (result) {


### PR DESCRIPTION
BugFix: submitblocks being ignored due to false positive

Prevents the following from happening when zcash daemon is busy during extensive RPC calls.
`2017-05-03 18:12:15 [Pool]      [zcash] (Thread 1) Warning, ignored new submit block while processing previous submit block.`
The bug is the boolean has the potential to get stuck true, making that thread always ignore submit blocks.
This sanity check is not required as duplicate block checking in paymentProcessor.js is finally solved.