### PR TITLE
MPOS Compat

### DIFF
--- a/lib/stratum.js
+++ b/lib/stratum.js
@@ -121,7 +121,7 @@ var StratumClient = function(options){
     }
 
     function handleAuthorize(message){
-        _this.workerName = message.params[0].split('.')[0];
+        _this.workerName = message.params[0];
         _this.workerPass = message.params[1];
 
         options.authorizeFn(_this.remoteAddress, options.socket.localPort, _this.workerName, _this.workerPass, function(result) {


### PR DESCRIPTION
Solved issue reported in z-classic/z-nomp gitter.
`vtnplus: i problem with z-nomp after update. workerName="username", last is workerName="username.worker" => error in mpos auth. where i can fix it`

`hellcatz: @vtnplus Maybe this line?
https://github.com/z-classic/node-stratum-pool/blob/master/lib/stratum.js#L124
The .split('.')[0]; was recently added, stripping workername from address....don't use MPOS here.....GL`

`vtnplus: thanks @hellcatz`