### PR TITLE
Fixed wrong 'Clean jobs' parameter index

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -298,7 +298,7 @@ var pool = module.exports = function pool(options, authorizeFn) {
             //Check if stratumServer has been initialized yet
             if (_this.stratumServer) {
                 var job = blockTemplate.getJobParams();
-                job[8] = false;
+                job[7] = false;
                 _this.stratumServer.broadcastMiningJobs(job);
             }
         }).on('share', function (shareData, blockHex) {
@@ -701,7 +701,7 @@ var pool = module.exports = function pool(options, authorizeFn) {
              //so the miner doesn't restart work and submit duplicate shares
              client.sendDifficulty(newDiff);
              var job = _this.jobManager.currentJob.getJobParams();
-             job[8] = false;
+             job[7] = false;
              client.sendMiningJob(job);
              }*/
 


### PR DESCRIPTION
Clean Jobs stratum parameter is being written to false on the wrong index. 9th element in the params array instead of the 8th. This could  cause miners to generate unneccesary duplicate shares.

